### PR TITLE
Add an option to enable suppression of the error popup 

### DIFF
--- a/src/qwr/error_popup.cpp
+++ b/src/qwr/error_popup.cpp
@@ -2,21 +2,26 @@
 
 #include "error_popup.h"
 
+#include <qwr/fb2k_adv_config.h>
 #include <qwr/delayed_executor.h>
 
 namespace qwr
 {
 
-void ReportErrorWithPopup( const std::string& title, const std::string& errorText )
+void ReportErrorWithPopup( const std::string& title, const std::string& errorText, const bool showPopup )
 {
-    const auto report = [title, errorText] {
+    const auto report = [title, errorText, showPopup] {
         assert( core_api::assert_main_thread() );
 
         FB2K_console_formatter() << title << ":\n"
                                  << errorText << "\n";
-        qwr::DelayedExecutor::GetInstance().AddTask( [errorText, title] {
-            popup_message::g_show( errorText.c_str(), title.c_str() );
-        } );
+
+        if (showPopup)
+        {
+            qwr::DelayedExecutor::GetInstance().AddTask( [errorText, title] {
+                popup_message::g_show( errorText.c_str(), title.c_str() );
+            } );
+        }
 
         MessageBeep( MB_ICONASTERISK );
     };

--- a/src/qwr/error_popup.h
+++ b/src/qwr/error_popup.h
@@ -5,6 +5,6 @@
 namespace qwr
 {
 
-void ReportErrorWithPopup( const std::string& title, const std::string& errorText );
+void ReportErrorWithPopup( const std::string& title, const std::string& errorText, bool showPopup = true );
 
 } // namespace qwr


### PR DESCRIPTION
This small PR adds a parameter which enables suppression of the popup (while still logging the error to the console)

see: https://github.com/TheQwertiest/foo_spider_monkey_panel/pull/147